### PR TITLE
feat: Added Authority Profile and Edit

### DIFF
--- a/app/controllers/authorities_controller.rb
+++ b/app/controllers/authorities_controller.rb
@@ -1,5 +1,5 @@
 class AuthoritiesController < ApplicationController
-    before_action :authority_block_access, except: [:destroy, :index]
+    before_action :authority_block_access, except: [:destroy, :show, :edit, :update]
     before_action :authority_authorize, except: [:new, :create, :list, :login, :check_login]
     before_action :admin_authorize, only: [:new, :create, :list]
 
@@ -18,8 +18,8 @@ class AuthoritiesController < ApplicationController
         end
     end
 
-    def index
-
+    def show
+        @authority = Authority.find_by(id: session[:authority_id])
     end
 
     def login
@@ -50,6 +50,20 @@ class AuthoritiesController < ApplicationController
         @authorities = Authority.select(:identifier, :name)
     end
 
+    def edit
+        @authority = Authority.find_by(id: session[:authority_id])
+    end
+    
+    def update
+        @authority = Authority.find_by(id: session[:authority_id])
+        if @authority.update(edit_params)
+            flash.alert = 'Profile updated!'
+            redirect_to '/authorities/profile'
+        else
+            render action: :edit
+        end
+    end
+
     def authority_sign_out
         session.delete(:authority_id)
         @current_authority = nil
@@ -57,7 +71,7 @@ class AuthoritiesController < ApplicationController
 
     def authority_block_access
         if authority_logged_in?
-            redirect_to '/authorities'
+            redirect_to '/authority'
         end
     end
 
@@ -73,6 +87,11 @@ class AuthoritiesController < ApplicationController
     private
     def authorities_params
         params.require(:authorities).permit(:identifier, :name, :password)
+    end
+
+    private
+    def edit_params
+        params.require(:authority).permit(:identifier, :name)
     end
 
 end

--- a/app/views/authorities/edit.html.erb
+++ b/app/views/authorities/edit.html.erb
@@ -1,0 +1,25 @@
+<h1> Editar Dados de Autoridade</h1>
+
+<% if @authority.errors.any? %>
+<div id="error_explanation">    
+    <ul>
+        <% @authority.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+        <% end %>
+    </ul>
+</div>
+<% end %>
+
+<%= form_with model: @authority, url: '/authorities/edit' do |form| %>
+    <p>
+        <%= form.label :identifier %><br />
+        <%= form.text_field :identifier %>
+    </p>
+    <p>
+        <%= form.label :name %><br />
+        <%= form.text_field :name %>
+    </p>
+    <p>
+        <%= form.submit 'Save' %>
+    </p>
+<% end %>

--- a/app/views/authorities/index.html.erb
+++ b/app/views/authorities/index.html.erb
@@ -1,3 +1,0 @@
-<h1> Página de Gerenciamento de Desastres</h1>
-
-<p><%= link_to "Log out", '/authorities/sign_out', method: :delete %></p>

--- a/app/views/authorities/show.html.erb
+++ b/app/views/authorities/show.html.erb
@@ -1,0 +1,13 @@
+<h1> Página de Autoridade</h1>
+
+<% flash.each do |type, msg| %>
+    <div id="success_explanation">    
+        <%= msg %>
+    </div>
+<% end %>
+
+<h3><%= @authority.name %>'s Profile </h3>
+<p>Identifier: <%= @authority.identifier %> </p>
+<p>Username: <%= @authority.name %> </p>
+<p><%= link_to "Edit Authority Profile", '/authorities/edit' %></p>
+<p><%= link_to "Log out", '/authorities/sign_out', method: :delete %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
 
   get "/authorities/login" => 'authorities#login'
   post "/authorities/login" => 'authorities#check_login'
+  get "/authorities/profile" => 'authorities#show'
+  get "/authorities/edit" => 'authorities#edit'
+  patch "/authorities/edit" => 'authorities#update'
   delete '/authorities/sign_out' => 'authorities#destroy'
 
   get "admin/login" => 'admins#new'

--- a/features/authority_edit.feature
+++ b/features/authority_edit.feature
@@ -1,0 +1,58 @@
+#language: pt
+
+@oneAuthorityBefore
+Funcionalidade: Editar Perfil de Autoridade
+Como autoridade
+Eu quero poder editar minhas informações cadastradas
+Para que eu corrija ou atualize dados que estão incorretos
+
+Cenário: Editar dados da Autoridade com sucesso
+Dado que estou logado como autoridade na página home
+Quando acesso a tela de edição de perfil de autoridade
+Quando preencho o campo "Identifier" com "190"
+Quando preencho o campo "Name" com "Policia"
+E clico em Save
+Então deverei ver a mensagem "Profile updated!"
+E ver o campo atualizado com "190"
+E ver o campo atualizado com "Policia"
+
+Cenário: Editar dados da Autoridade com sucesso - mantendo o mesmo identificador
+Dado que estou logado como autoridade na página home
+Quando acesso a tela de edição de perfil de autoridade
+Quando preencho o campo "Identifier" com "193"
+Quando preencho o campo "Name" com "Corpo de Bombeiros Zona X"
+E clico em Save
+Então deverei ver a mensagem "Profile updated!"
+E ver o campo atualizado com "Corpo de Bombeiros Zona X"
+
+Cenário: Editar dados da Autoridade com erro - sem identificador
+Dado que estou logado como autoridade na página home
+Quando acesso a tela de edição de perfil de autoridade
+Quando deixo o campo "Identifier" vazio
+Quando preencho o campo "Name" com "Policia"
+E clico em Save
+Então deverei ver a mensagem "É obrigatório informar o identificador!"
+
+Cenário: Editar dados da Autoridade com erro - sem nome
+Dado que estou logado como autoridade na página home
+Quando acesso a tela de edição de perfil de autoridade
+Quando preencho o campo "Identifier" com "190"
+Quando deixo o campo "Name" vazio
+E clico em Save
+Então deverei ver a mensagem "É obrigatório informar o nome!"
+
+@otherAuthorityBefore
+Cenário: Editar dados da Autoridade com erro - identificador indisponível
+Dado que estou logado como autoridade na página home
+Quando acesso a tela de edição de perfil de autoridade
+Quando preencho o campo "Identifier" com "190"
+Quando preencho o campo "Name" com "Policia"
+E clico em Save
+Então deverei ver a mensagem "Identificador não está disponível!"
+
+Cenário: Editar dados da Autoridade com erro - autoridade não logado
+Dado que não estou logado como autoridade na página home
+Quando acesso a tela de edição de perfil de autoridade
+Então deverei ser redirecionado para a página de login de autoridade
+
+

--- a/features/step_definitions/authority_edit_step.rb
+++ b/features/step_definitions/authority_edit_step.rb
@@ -1,0 +1,3 @@
+Quando('acesso a tela de edição de perfil de autoridade') do
+    visit 'authorities/edit'
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -30,3 +30,7 @@ Before('@otherUserMarkerBefore') do
     user2 = User.new(name: "Aleatory", username:"ale",email:"ale@mail.com",birth_date: Date.parse("10/10/1000"), password:"holyhowdy").save
     marker1 = Marker.new(disaster_type: 'incendio', latitude: 26.1232, longitude: -23.3323, user_id: (User.order("id").last).id, verified: false).save
 end
+
+Before('@otherAuthorityBefore') do
+    authority2 = Authority.new(identifier: 190, name: "Policia", password: "SenhaDaPoliciaTeste").save
+end

--- a/spec/requests/authorities_spec.rb
+++ b/spec/requests/authorities_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Authorities", type: :request do
       it 'block access to login' do
         allow_any_instance_of(AuthoritiesController).to receive(:authority_logged_in?).and_return(true)
         get '/authorities/login'
-        expect(response).to redirect_to('/authorities')
+        expect(response).to redirect_to('/authority')
       end
     end
   end
@@ -32,6 +32,70 @@ RSpec.describe "Authorities", type: :request do
     it 'signs the authority in' do
       post '/authorities/login', params: @params
       expect(session[:authority_id]).to eql(@a.id)
+    end
+  end
+
+  describe "GET /authorities/profile" do
+    context "logged in" do
+      before :each do
+        @a = double('authority1', :id => 1, :identifier => 193, :password => 'SenhaDosBombeirosTeste', :name => 'Corpo de Bombeiros')
+        @params = {identifier: 193, password: 'SenhaDosBombeirosTeste'}
+
+        allow_any_instance_of(AuthoritiesController).to receive(:authority_block_access)
+        allow(@a).to receive(:authenticate).with('SenhaDosBombeirosTeste') {@a}
+        
+        expect(Authority).to receive(:find_by).with({:identifier=> '193'}).and_return(@a)
+        post '/authorities/login', params: @params
+        allow(Authority).to receive(:find_by).with({:id=> 1}).and_return(@a)
+      end
+      it 'returns http success' do
+        get '/authorities/profile'
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /authorities/edit" do
+    before :each do
+      @modelName = double("MName")
+      allow(@modelName).to receive(:param_key).and_return("Authority")
+      @a = double('authority1', :id => 1, :model_name => @modelName, :identifier => 193, :password => 'SenhaDosBombeirosTeste', :name => 'Corpo de Bombeiros', :errors => double('error'))
+      allow(@a.errors).to receive(:any?).and_return(false)
+      @params = {identifier: 193, password: 'SenhaDosBombeirosTeste'}
+      
+      allow_any_instance_of(AuthoritiesController).to receive(:authority_block_access)
+      allow(@a).to receive(:authenticate).with('SenhaDosBombeirosTeste') {@a}
+      
+      expect(Authority).to receive(:find_by).with({:identifier=> '193'}).and_return(@a)
+      post '/authorities/login', params: @params
+      allow(Authority).to receive(:find_by).with({:id=> 1}).and_return(@a)
+    end
+    it 'returns http success' do
+      get '/authorities/edit'
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "PATCH /authorities/edit" do
+    before :each do
+      @modelName = double("MName")
+      allow(@modelName).to receive(:param_key).and_return("Authority")
+      @a = double('authority1', :id => 1, :model_name => @modelName, :identifier => 193, :password => 'SenhaDosBombeirosTeste', :name => 'Corpo de Bombeiros', :errors => double('error'))
+      allow(@a.errors).to receive(:any?).and_return(false)
+      @params = {identifier: 193, password: 'SenhaDosBombeirosTeste'}
+      
+      allow_any_instance_of(AuthoritiesController).to receive(:authority_block_access)
+      allow(@a).to receive(:authenticate).with('SenhaDosBombeirosTeste') {@a}
+      
+      expect(Authority).to receive(:find_by).with({:identifier=> '193'}).and_return(@a)
+      post '/authorities/login', params: @params
+      allow(Authority).to receive(:find_by).with({:id=> 1}).and_return(@a)
+      allow_any_instance_of(AuthoritiesController).to receive(:edit_params).and_return(1)
+    end
+    it 'returns http success' do
+      expect(@a).to receive(:update).with(1).and_return(true)
+      patch "/authorities/edit", params: { authority: { identifier: "190", name: "Policia"}}
+      expect(response).to redirect_to('/authorities/profile')
     end
   end
 


### PR DESCRIPTION
## What?
Added the Authority Profile where they can see their information and Authority Edit to enable possible changes in Authorities data.

## Why?
In our system, it's important Authorities be able to see and change their information that is registered in our plataform

## How?
It was created a new page to show Authority their registered information and a new button redirecting to a Edit Page where they can change their data

## Testing?
Tests with RSpec and Cucumber used.